### PR TITLE
[3.6] Limit when values of a select is an entity

### DIFF
--- a/app/view/twig/editcontent/fields/_image.twig
+++ b/app/view/twig/editcontent/fields/_image.twig
@@ -54,7 +54,7 @@
 
 {% set attribute_fields = [] %}
 {% for attrib in option.attrib|default([]) %}
-    {% set aid = attrib|lower|replace({'alt text': 'alt'}) %}
+    {% set aid = attrib|lower|replace({' ': '_'}) %}
 
     {% if aid is not empty %}
         {% if aid == 'title' %}
@@ -62,7 +62,7 @@
         {% elseif aid == 'alt' %}
             {% set atitle = __('field.image.label.alt') %}
         {% else %}
-            {% set atitle = aid %}
+            {% set atitle = attrib %}
         {% endif %}
 
         {% set uid = key ~ '-' ~ aid %}

--- a/app/view/twig/editcontent/fields/_image.twig
+++ b/app/view/twig/editcontent/fields/_image.twig
@@ -56,11 +56,13 @@
 {% for attrib in option.attrib|default([]) %}
     {% set aid = attrib|lower|replace({'alt text': 'alt'}) %}
 
-    {% if aid in ['title', 'alt'] %}
+    {% if aid is not empty %}
         {% if aid == 'title' %}
             {% set atitle = __('general.phrase.title') %}
         {% elseif aid == 'alt' %}
             {% set atitle = __('field.image.label.alt') %}
+        {% else %}
+            {% set atitle = aid %}
         {% endif %}
 
         {% set uid = key ~ '-' ~ aid %}

--- a/src/Form/Resolver/Choice.php
+++ b/src/Form/Resolver/Choice.php
@@ -146,6 +146,7 @@ final class Choice
 
         $filter = $field->get('filter');
         $filter['order'] = $field->get('sort');
+        $filter['limit'] = $field->get('limit') ?? 500;
         /** @var QueryResultset $entities */
         $entities = $this->query->getContent($contentType, $filter);
         if (!$entities) {

--- a/src/Form/Resolver/Choice.php
+++ b/src/Form/Resolver/Choice.php
@@ -115,7 +115,7 @@ final class Choice
      */
     private function getYamlValues(Bag $field)
     {
-        $values = array_slice($field->get('values', []), 0, $field->get('limit', DEFAULT_LIMIT), true);
+        $values = array_slice($field->get('values', []), 0, $field->get('limit', self::DEFAULT_LIMIT), true);
         if ($field->get('sortable')) {
             asort($values, SORT_REGULAR);
         }
@@ -148,7 +148,7 @@ final class Choice
 
         $filter = $field->get('filter');
         $filter['order'] = $field->get('sort');
-        $filter['limit'] = $field->get('limit', DEFAULT_LIMIT);
+        $filter['limit'] = $field->get('limit', self::DEFAULT_LIMIT);
         /** @var QueryResultset $entities */
         $entities = $this->query->getContent($contentType, $filter);
         if (!$entities) {

--- a/src/Form/Resolver/Choice.php
+++ b/src/Form/Resolver/Choice.php
@@ -17,6 +17,8 @@ use Bolt\Storage\Query\QueryResultset;
  */
 final class Choice
 {
+    const DEFAULT_LIMIT = 500;
+    
     /** @var Query */
     private $query;
 
@@ -113,7 +115,7 @@ final class Choice
      */
     private function getYamlValues(Bag $field)
     {
-        $values = array_slice($field->get('values', []), 0, $field->get('limit', 500), true);
+        $values = array_slice($field->get('values', []), 0, $field->get('limit', DEFAULT_LIMIT), true);
         if ($field->get('sortable')) {
             asort($values, SORT_REGULAR);
         }
@@ -146,7 +148,7 @@ final class Choice
 
         $filter = $field->get('filter');
         $filter['order'] = $field->get('sort');
-        $filter['limit'] = $field->get('limit', 500);
+        $filter['limit'] = $field->get('limit', DEFAULT_LIMIT);
         /** @var QueryResultset $entities */
         $entities = $this->query->getContent($contentType, $filter);
         if (!$entities) {

--- a/src/Form/Resolver/Choice.php
+++ b/src/Form/Resolver/Choice.php
@@ -113,7 +113,7 @@ final class Choice
      */
     private function getYamlValues(Bag $field)
     {
-        $values = array_slice($field->get('values', []), 0, $field->get('limit'), true);
+        $values = array_slice($field->get('values', []), 0, $field->get('limit', 500), true);
         if ($field->get('sortable')) {
             asort($values, SORT_REGULAR);
         }
@@ -146,7 +146,7 @@ final class Choice
 
         $filter = $field->get('filter');
         $filter['order'] = $field->get('sort');
-        $filter['limit'] = $field->get('limit') ?? 500;
+        $filter['limit'] = $field->get('limit', 500);
         /** @var QueryResultset $entities */
         $entities = $this->query->getContent($contentType, $filter);
         if (!$entities) {

--- a/tests/phpunit/unit/Form/Resolver/ChoiceTest.php
+++ b/tests/phpunit/unit/Form/Resolver/ChoiceTest.php
@@ -320,7 +320,7 @@ class ChoiceTest extends TestCase
         $mockQuery
             ->expects($this->at(0))
             ->method('getContent')
-            ->with('contenttype', ['order' => $expected])
+            ->with('contenttype', ['order' => $expected, 'limit' => Choice::DEFAULT_LIMIT])
         ;
 
         $resolver = new Choice($mockQuery);


### PR DESCRIPTION
The use of the limit, in a field of type select, only happens when the values are of type Yaml. This small change makes it possible to use threshold when the value is an entity.

A major problem that can occur with the lack of this feature is when a filter is not used and returns many results. Because there is no limit, the query may break the application and return a fatal error.

Usage
-------
```yaml
...
  fields:
    breaking_news:
      type: select
      values: entries/id,title
      keys: slug
      sort: -id
      limit: 10
```

If the property is not specified, the default limit of 500 is considered.
